### PR TITLE
ci: Expand PR title validation triggers

### DIFF
--- a/.github/workflows/validate_pr_title.yaml
+++ b/.github/workflows/validate_pr_title.yaml
@@ -1,11 +1,18 @@
 name: "Validate PR Title"
 
 on:
+  # NOTE: Force-pushes from automated PRs (like release-please) do not seem to
+  # trigger any of the normal PR triggers (opened, edited, synchronize).  In
+  # fact, even an exhaustive list of types will not work.  So here we add
+  # triggers for reviews, so that the validation will run after someone
+  # approves such a PR.  This is critical since this is a required status check
+  # in most of our repos.  If it doesn't run, the PR can't be merged.
   pull_request_target:
     types:
       - opened
       - edited
       - synchronize
+  pull_request_review:
 
 jobs:
   main:


### PR DESCRIPTION
Force-pushes from automated PRs (like release-please) do not seem to
trigger any of the normal PR triggers (opened, edited, synchronize).
In fact, even an exhaustive list of types will not work.  So here we
add triggers for reviews, so that the validation will run after
someone approves such a PR.  This is critical since this is a required
status check in most of our repos.  If the workflow doesn't run, the
release PR can't be merged.

## Description

<!--
  Give the PR a helpful title that summaries what this PR changes. Here, include
  a summary of the change and which issue is fixed. Also include relevant
  motivation and context. List any dependencies that are required for this
  change.

  If this fixes any issues, include lines like this:
  Fixes #123
-->


## Screenshots (optional)

<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have signed the Google CLA <https://cla.developers.google.com>
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [ ] I have run `./build/all.py` and the build passes
- [ ] I have run `./build/test.py` and all tests pass
